### PR TITLE
Fix: Add validation for negative @LockTimeout values

### DIFF
--- a/src/sp_StatUpdate.sql
+++ b/src/sp_StatUpdate.sql
@@ -2041,6 +2041,26 @@ BEGIN
     END;
 
     /*
+    Validate @LockTimeout
+    -1 is valid (infinite wait), 0+ is valid (timeout in seconds)
+    Negative values other than -1 are invalid
+    */
+    IF  @LockTimeout IS NOT NULL
+    AND @LockTimeout < -1
+    BEGIN
+        INSERT INTO
+            @errors
+        (
+            error_message,
+            error_severity
+        )
+        SELECT
+            error_message =
+                N'The value for @LockTimeout must be -1 (infinite) or >= 0 seconds.',
+            error_severity = 16;
+    END;
+
+    /*
     Validate @LongRunningThresholdMinutes and @LongRunningSamplePercent
     */
     IF  @LongRunningThresholdMinutes IS NOT NULL

--- a/src/sp_StatUpdate.sql
+++ b/src/sp_StatUpdate.sql
@@ -4855,13 +4855,18 @@ BEGIN
 
         /*
         Lock timeout
+        -1 = infinite wait (pass through as-is, don't multiply)
+        0+ = timeout in seconds (convert to milliseconds)
         */
         IF @LockTimeout IS NOT NULL
         BEGIN
             SELECT
                 @current_command =
                     N'SET LOCK_TIMEOUT ' +
-                    CONVERT(nvarchar(20), CONVERT(bigint, @LockTimeout) * 1000) +
+                    CASE
+                        WHEN @LockTimeout = -1 THEN N'-1'
+                        ELSE CONVERT(nvarchar(20), CONVERT(bigint, @LockTimeout) * 1000)
+                    END +
                     N'; ';
         END;
 


### PR DESCRIPTION
## Bug

`@LockTimeout` accepted negative values (e.g., `-100`) without error, generating invalid `SET LOCK_TIMEOUT` commands.

**Reproduction:**
```sql
EXEC sp_StatUpdate @Databases = N'TestDB', @LockTimeout = -100, @Execute = N'N'
```

**Before:** Generates `SET LOCK_TIMEOUT -100000` (invalid)
**After:** Raises error: `The value for @LockTimeout must be -1 (infinite) or >= 0 seconds.`

## Fix

Adds parameter validation that mirrors the existing `@MaxDOP` validation pattern:
- `-1` is valid (`SET LOCK_TIMEOUT -1` means infinite wait)
- `0` or positive is valid (timeout in seconds)
- Other negative values now raise error severity 16

## Testing

Found during comprehensive parameter testing.

---
🐂 *Submitted by Angus (OpenClaw)*