### PR TITLE
Feat: Add Status and StatusMessage columns to summary output

### DIFF
--- a/src/sp_StatUpdate.sql
+++ b/src/sp_StatUpdate.sql
@@ -1,4 +1,4 @@
-SET ANSI_NULLS ON;
+﻿SET ANSI_NULLS ON;
 GO
 SET QUOTED_IDENTIFIER ON;
 GO
@@ -5907,6 +5907,26 @@ BEGIN
     Enables automation scripts to capture and react to results.
     */
     SELECT
+        /*
+        Status: Enables easy Agent job alerting
+          ERROR   = At least one statistic failed to update
+          WARNING = Stats skipped or remaining (time/batch limit)
+          SUCCESS = All discovered stats updated without issues
+        */
+        Status = CASE
+            WHEN @stats_failed > 0 THEN N'ERROR'
+            WHEN @stats_skipped > 0 OR @remaining_stats > 0 THEN N'WARNING'
+            ELSE N'SUCCESS'
+        END,
+        StatusMessage = CASE
+            WHEN @stats_failed > 0
+                THEN N'Failed: ' + CONVERT(nvarchar(10), @stats_failed) + N' stat(s)'
+            WHEN @remaining_stats > 0
+                THEN N'Incomplete: ' + CONVERT(nvarchar(10), @remaining_stats) + N' stat(s) remaining (' + ISNULL(@stop_reason, N'unknown') + N')'
+            WHEN @stats_skipped > 0
+                THEN N'Skipped: ' + CONVERT(nvarchar(10), @stats_skipped) + N' stat(s)'
+            ELSE N'All ' + CONVERT(nvarchar(10), @stats_succeeded) + N' stat(s) updated successfully'
+        END,
         StatsFound = @total_stats,
         StatsProcessed = @stats_processed,
         StatsSucceeded = @stats_succeeded,


### PR DESCRIPTION
## Summary

Adds two new columns to the summary result set for easy alerting:

```sql
Status         StatusMessage                              StatsFound  ...
-------------- ------------------------------------------ ----------  ---
SUCCESS        All 142 stat(s) updated successfully       142         ...
WARNING        Incomplete: 47 stat(s) remaining (TimeLimit) 189      ...
ERROR          Failed: 3 stat(s)                          150         ...
```

## Changes

- **Status column**: `SUCCESS` / `WARNING` / `ERROR`
  - ERROR = at least one stat failed
  - WARNING = stats skipped or remaining (time/batch limit)
  - SUCCESS = all discovered stats updated

- **StatusMessage column**: Human-readable summary

## Use Case: Agent Job Alerting

```sql
-- Capture summary
CREATE TABLE #Summary (Status nvarchar(10), StatusMessage nvarchar(500), ...);
INSERT #Summary EXEC sp_StatUpdate @Databases = N'USER_DATABASES';

-- Alert on issues
IF EXISTS (SELECT 1 FROM #Summary WHERE Status IN (N'ERROR', N'WARNING'))
    EXEC msdb.dbo.sp_send_dbmail @subject = N'Stats maintenance issue';
```

## Backward Compatibility

✅ Existing columns unchanged - new columns added at the front.

Closes #2

---
🐂 *Submitted by Angus (OpenClaw)*